### PR TITLE
Performance improvement for the batch connector under high load

### DIFF
--- a/lib/riemannx/connections/batch.ex
+++ b/lib/riemannx/connections/batch.ex
@@ -34,6 +34,13 @@ defmodule Riemannx.Connections.Batch do
 
   @behaviour Riemannx.Connection
 
+  defstruct [
+    :queue,
+    {:pending_flush, false},
+    {:ongoing_flush, false},
+    :flush_ref
+  ]
+
   # ===========================================================================
   # API
   # ===========================================================================
@@ -45,24 +52,29 @@ defmodule Riemannx.Connections.Batch do
   # GenStage Callbacks
   # ===========================================================================
   def start_link([]) do
-    GenServer.start_link(__MODULE__, Qex.new(), name: __MODULE__)
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
   end
 
-  def init(queue) do
+  def init(_) do
     Process.send_after(self(), :flush, batch_interval())
-    {:ok, queue}
+    {:ok, %__MODULE__{queue: Qex.new()}}
   end
 
-  def handle_cast({:push, event}, queue) do
-    queue = Qex.push(queue, event)
+  def handle_cast({:push, event}, state) do
+    state = push(state, event)
 
-    if Enum.count(queue) >= batch_size(),
-      do: {:noreply, flush(queue)},
-      else: {:noreply, queue}
+    if queue_size(state) >= batch_size(),
+      do: {:noreply, flush(state)},
+      else: {:noreply, state}
   end
 
-  def handle_info(:flush, queue), do: {:noreply, flush(queue)}
-  def handle_info(_, queue), do: {:noreply, queue}
+  def handle_info(:flush, state), do: {:noreply, flush(state)}
+
+  # a previous flush is finished, check if anyone requested another one in the meantime
+  def handle_info({:DOWN, ref, :process, _, _}, state = %__MODULE__{flush_ref: ref}),
+    do: {:noreply, state |> clear_ongoing_flush() |> flush_if_pending()}
+
+  def handle_info(_, state), do: {:noreply, state}
 
   # ===========================================================================
   # Private
@@ -73,16 +85,44 @@ defmodule Riemannx.Connections.Batch do
         item
       end)
 
-    [events: batch]
-    |> Msg.new()
-    |> Msg.encode()
-    |> batch_module().send_async()
+    {_, ref} =
+      spawn_monitor(fn ->
+        [events: batch]
+        |> Msg.new()
+        |> Msg.encode()
+        |> batch_module().send_async()
+      end)
 
     Process.send_after(self(), :flush, batch_interval())
+    ref
   end
 
-  defp flush(queue) do
-    queue |> Enum.to_list() |> flush()
-    Qex.new()
+  defp flush(state = %__MODULE__{ongoing_flush: true}) do
+    # try again when the flush is done
+    %__MODULE__{state | pending_flush: true}
   end
+
+  defp flush(state = %__MODULE__{queue: queue}) do
+    ref = queue |> Enum.to_list() |> flush()
+
+    %__MODULE__{
+      state
+      | pending_flush: false,
+        ongoing_flush: true,
+        flush_ref: ref,
+        queue: Qex.new()
+    }
+  end
+
+  defp flush_if_pending(state = %__MODULE__{pending_flush: true}), do: flush(state)
+  defp flush_if_pending(state), do: state
+
+  defp clear_ongoing_flush(state = %__MODULE__{}),
+    do: %__MODULE__{state | ongoing_flush: false, flush_ref: nil}
+
+  defp push(state = %__MODULE__{queue: queue}, event) do
+    %__MODULE__{state | queue: Qex.push(queue, event)}
+  end
+
+  defp queue_size(%__MODULE__{queue: queue}), do: Enum.count(queue)
 end


### PR DESCRIPTION
There is an issue where high message pressure on connection procs can cause severe performance degradation. This happens because checking out a poolboy worker is a gen call, which necessarily requires a selective receive for a message that ends up at the end of a very long mailbox, so even seemingly fast async sends can become very expensive.

This is a problem with all connection types; batch is easiest to fix because it isolates the problem to a single process, while using the tcp/udp connections directly will place the bottleneck in all the consumer processes. This PR only addresses the batch connection.

The easiest approach is to simply move the flush that contains the poolboy checkout into a newly spawned process, which will start with an empty mailbox and will thus avoid the expensive selective receive. This, however, may cause packets to become reordered, which may be critical to client applications, since many spawned flush procs will be executed in whichever order the scheduler decides is optimal. To avoid this a simple locking mechanism is added, where only one flush will be allowed to run at a time, preserving the current effective behaviour.