### PR TITLE
Track queue size to avoid costly calculations under load

### DIFF
--- a/test/riemannx_batch_test.exs
+++ b/test/riemannx_batch_test.exs
@@ -118,6 +118,7 @@ defmodule RiemannxTest.Batch do
       Riemannx.send_async(event)
     end)
 
+    assert_queue_size() == true
     refute assert_events_received(event, 5000)
     Riemannx.send_async(event)
 
@@ -137,6 +138,7 @@ defmodule RiemannxTest.Batch do
     end)
 
     events = Enum.map(1..9, fn _ -> event end)
+    assert_queue_size() == true
     assert assert_events_received(events, 1000)
   end
 
@@ -154,6 +156,7 @@ defmodule RiemannxTest.Batch do
 
     for _ <- 1..batch_number do
       for e <- events, do: Riemannx.send_async(e)
+      assert_queue_size() == true
       assert assert_events_received(events, 1000)
       :timer.sleep(batch_interval() + 100)
     end
@@ -224,5 +227,10 @@ defmodule RiemannxTest.Batch do
     after
       10_000 -> false
     end
+  end
+
+  def assert_queue_size do
+    %{queue: queue, size: size} = :sys.get_state(Batch)
+    size == Enum.count(queue)
   end
 end


### PR DESCRIPTION
## Issue
Under heavy load the `Batch` process starts to consume a lot of memory. The identified issue is that if the queue grows too large in the process, it has to repeatedly calculate the length of the queue which becomes a costly operation (O(n)).

## Solution
Keep track of the size of the queue when items are pushed or pulled so there is no calculation needed.
