### PR TITLE
Track queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ config :riemannx, [
   batch_settings: [
     type: :combined # The underlying connection to use when using batching.
     size: 50, # The size of batches to send to riemann.
-    interval: {1, :seconds} # The interval at which to send batches.
+    interval: {1, :seconds}, # The interval at which to send batches.
+    limit: :infinity # The max limit of batches allowed in the batching queue
   ]
   tcp: [
     port: 5555,
@@ -248,6 +249,8 @@ Batching as of 4.0.0 is the default connection behaviour - the default batch siz
 * Batches will be dropped if no workers are available to handle the batch unless `checkout_timer` is set to `:infinity`
 
 There is a new type called `:batch` and a settings key called `batch_settings:`, inside batch_settings you can specify a type for the underlying connection (`:tcp`, `:udp`, `:combined`, `:tls`). As always combined is the default.
+
+Optionally, a batch limit number can be specified (`:limit`). If set, once the batching queue has the specified amount of batches, that is `limit * batch_size` events, new events will be dropped until at least one batch is sent. Default value is `:infinity`
 
 ### Micro Time<a name="micro-time"></a>
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -3,4 +3,5 @@ use Mix.Config
 config :riemannx,
   host: "localhost",
   tcp: [port: 5555, pool_size: 0],
-  udp: [port: 5555, pool_size: 0]
+  udp: [port: 5555, pool_size: 0],
+  batch_settings: [limit: 1000]

--- a/lib/riemannx/settings.ex
+++ b/lib/riemannx/settings.ex
@@ -159,6 +159,16 @@ defmodule Riemannx.Settings do
   def batch_size, do: settings_module().batch_size()
 
   @doc """
+  Returns the batch limit for queued batches to be send.
+
+  NOTE: If the limit is reached new events are dropped
+
+  Default: infinity
+  """
+  @spec batch_limit() :: integer() | :infinity
+  def batch_limit, do: settings_module().batch_limit()
+
+  @doc """
   Returns the batch interval.
 
   Default: {1, :minutes}

--- a/lib/riemannx/settings/default.ex
+++ b/lib/riemannx/settings/default.ex
@@ -62,6 +62,9 @@ defmodule Riemannx.Settings.Default do
   @spec batch_size() :: integer()
   def batch_size, do: extract_batch(:size, 100)
 
+  @spec batch_limit() :: integer() | :infinity
+  def batch_limit, do: extract_batch(:limit, :infinity)
+
   @spec batch_interval() :: integer()
   def batch_interval, do: interval(extract_batch(:interval, {10, :seconds}))
   defp interval({x, :minutes}), do: interval({x * 60, :seconds})

--- a/test/riemannx_batch_queue_test.exs
+++ b/test/riemannx_batch_queue_test.exs
@@ -24,7 +24,7 @@ defmodule RiemannxTest.BatchQueue do
     assert batch == batch1
 
     ## Add more events and test second batch
-    q3 = Enum.reduce(events1, q2, push_fun)
+    q3 = Enum.reduce(events2, q2, push_fun)
     {:ok, {_q4, batch}} = Queue.get_batch(q3)
     assert batch == batch2
   end


### PR DESCRIPTION
## Problems

This PR addresses two issues in the batching module:

1. `Enum.empty?/1` is taking too much time when the number of batches grows as due to internal conversions made

```erlang
[
   {:queue, :to_list, 1, [file: 'queue.erl', line: 90]},
   {Enumerable.Qex, :reduce, 3, [file: 'lib/impls/enumerable.ex', line: 9]},
   {Enum, :empty?, 1, [file: 'lib/enum.ex', line: 808]}
```

2. The batching module has the potential to grow indefinitely if it is receiving too many events. This scenario results in the application being killed due to OOM

## Solutions

1. Keep the count of already prepared batches
2. Added an optional mechanism to limit the amount of batches that can be in the queue. If the limit is reached, new events are dropped.